### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Simple script to scrape the unity download archive for version and change set info
 
 ### Setup and running
-- `(npm / yarn) install` to install the dependencies
-- `(npm / yarn) start` to run the script
+- `yarn install` to install the dependencies
+- `yarn start` to run the script
 
-### Enviornment Variables
+### Environment variables
 - `UNITY_ARCHIVE_URL` - URL for the unity archive page, defaults to (https://unity3d.com/get-unity/download/archive)
 - `UNITY_VERSIONS_PATH` - path + filename of the output versions json, defaults to (__dirname + '/unity-versions.json')


### PR DESCRIPTION
- Since the lockfile is for yarn and not npm i would suggest removing the `npm`  part and keeping `yarn`.
- Fix typo in environment variables title